### PR TITLE
[FEAT] 회원의 미션 상태별 개수 조회 API

### DIFF
--- a/oneco/src/main/java/com/oneco/backend/mission/application/port/out/MissionPersistencePort.java
+++ b/oneco/src/main/java/com/oneco/backend/mission/application/port/out/MissionPersistencePort.java
@@ -6,6 +6,7 @@ import java.util.List;
 import com.oneco.backend.category.domain.category.CategoryId;
 import com.oneco.backend.family.domain.relation.FamilyRelationId;
 import com.oneco.backend.mission.domain.mission.Mission;
+import com.oneco.backend.mission.domain.mission.MissionStatus;
 
 public interface MissionPersistencePort {
 	Mission save(Mission mission);
@@ -25,4 +26,10 @@ public interface MissionPersistencePort {
 
 	// 오늘이 미션 시작일인 모든 미션을 조회한다.
 	List<Mission> findAllMissionsStartingToday(LocalDate today);
+
+	// 가족관계를 기반으로 미션 개수를 조회한다.
+	long countMissionsByFamilyRelation(FamilyRelationId relationId);
+
+	// 가족관계를 기반으로 주어진 상태 목록의 미션 개수를 조회한다.
+	long countMissionsByFamilyRelationAndStatuses(FamilyRelationId relationId, List<MissionStatus> statuses);
 }

--- a/oneco/src/main/java/com/oneco/backend/mission/infrastructure/MissionJpaRepository.java
+++ b/oneco/src/main/java/com/oneco/backend/mission/infrastructure/MissionJpaRepository.java
@@ -80,4 +80,8 @@ public interface MissionJpaRepository extends JpaRepository<Mission, Long> {
 		@Param("today") LocalDate today,
 		@Param("status") MissionStatus status
 	);
+
+	long countByFamilyRelationIdValue(Long value);
+
+	long countByFamilyRelationIdValueAndStatusIn(Long value, List<MissionStatus> statuses);
 }

--- a/oneco/src/main/java/com/oneco/backend/mission/infrastructure/MissionPersistenceAdapter.java
+++ b/oneco/src/main/java/com/oneco/backend/mission/infrastructure/MissionPersistenceAdapter.java
@@ -77,4 +77,14 @@ public class MissionPersistenceAdapter implements MissionPersistencePort {
 	public List<Mission> findAllMissionsStartingToday(LocalDate today) {
 		return repository.findAllByStartDate(today, MissionStatus.APPROVAL_ACCEPTED);
 	}
+
+	@Override
+	public long countMissionsByFamilyRelation(FamilyRelationId relationId) {
+		return repository.countByFamilyRelationIdValue(relationId.getValue());
+	}
+
+	@Override
+	public long countMissionsByFamilyRelationAndStatuses(FamilyRelationId relationId, List<MissionStatus> statuses) {
+		return repository.countByFamilyRelationIdValueAndStatusIn(relationId.getValue(), statuses);
+	}
 }

--- a/oneco/src/main/java/com/oneco/backend/mission/presentation/MissionController.java
+++ b/oneco/src/main/java/com/oneco/backend/mission/presentation/MissionController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.oneco.backend.global.response.CursorResponse;
@@ -22,6 +23,7 @@ import com.oneco.backend.mission.application.service.MissionReadService;
 import com.oneco.backend.mission.presentation.request.ApproveMissionRequest;
 import com.oneco.backend.mission.presentation.request.CreateMissionRequest;
 import com.oneco.backend.mission.presentation.request.MissionCursorRequest;
+import com.oneco.backend.mission.presentation.response.MissionCountResponse;
 import com.oneco.backend.mission.presentation.response.MissionResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -130,4 +132,16 @@ public class MissionController {
 	// 미션 진행중 -> 실패 전환(조기 실패)은 API 없음, StudyRecord 도메인에서 (MissionStatusChange을 주입) 에서 처리한다.
 	// 미션 진행중 -> 실패 전환(기간 만료)는 API 없음, Mission 도메인에서 MissionBatchService(스케줄러)로 처리한다.
 	// 미션 삭제 API는 당장은 없음(미션 기록 보존을 위해 삭제 기능은 추후에 별도로 논의)
+
+	// 나의 미션 개수
+	// 쿼리 파라미터로 필터링 기능을 제공한다.
+	// API 요청 예시 - 전체 미션 개수: /api/missions/me/count
+	@GetMapping("me/count")
+	public ResponseEntity<DataResponse<MissionCountResponse>> getMyMissionCount(
+		@Parameter(hidden = true) @AuthenticationPrincipal JwtPrincipal principal
+	) {
+		MemberId memberId = MemberId.of(principal.memberId());
+		MissionCountResponse response = missionReadService.countMyMissions(memberId);
+		return ResponseEntity.ok(DataResponse.from(response));
+	}
 }

--- a/oneco/src/main/java/com/oneco/backend/mission/presentation/response/MissionCountResponse.java
+++ b/oneco/src/main/java/com/oneco/backend/mission/presentation/response/MissionCountResponse.java
@@ -1,0 +1,12 @@
+package com.oneco.backend.mission.presentation.response;
+
+public record MissionCountResponse(
+	long totalMissionCount,
+	long inProgressMissionCount,
+	long finishedMissionCount
+) {
+	public static MissionCountResponse of(long totalMissionCount, long inProgressMissionCount,
+		long finishedMissionCount) {
+		return new MissionCountResponse(totalMissionCount, inProgressMissionCount, finishedMissionCount);
+	}
+}


### PR DESCRIPTION
## 🗒️ Description
- 회원별 미션 상태(예: 진행중/완료/실패 등) 개수를 조회하는 API를 추가했습니다.
- MissionController에 새로운 조회 엔드포인트를 노출하고, 서비스/포트/리포지토리 계층에 상태별 카운트 조회 로직을 구현했습니다.
- 응답 DTO(MissionCountResponse)를 추가해 상태별 개수를 명시적으로 전달합니다.

## 🔗 Relation Issue
- close #63

<img width="278" height="141" alt="image" src="https://github.com/user-attachments/assets/c3407ac0-7678-46f0-8325-79d79fed391e" />
