### PR TITLE
[FIX] 배포환경 Swagger 문서 적용

### DIFF
--- a/oneco/src/main/java/com/oneco/backend/global/config/SwaggerConfig.java
+++ b/oneco/src/main/java/com/oneco/backend/global/config/SwaggerConfig.java
@@ -123,6 +123,16 @@ public class SwaggerConfig {
 			.build();
 	}
 
+	@Bean
+	public GroupedOpenApi HomeApi() {
+		return GroupedOpenApi.builder()
+			.group("Home")
+			.displayName("Home (홈화면)")
+			.packagesToScan("com.oneco.backend.StudyRecord.presentation")
+			.pathsToMatch("/api/home/**")
+			.build();
+	}
+
 	// === 공통 에러 응답 자동 추가 ===
 	@Bean
 	public OperationCustomizer addGlobalResponses() {


### PR DESCRIPTION
## 1. 한줄 요약 (What / Why)
- What: Swagger에 Home API 그룹을 추가하고 PR 템플릿·작성 가이드를 정비했습니다.
- Why: 배포 환경에서도 홈 화면 엔드포인트가 문서화되도록 하고, 리뷰 준비 과정을 통일하려는 목적입니다.

## 2. 리뷰 포인트 (최대 3개)
1. Home API 그룹의 `packagesToScan` 경로와 `/api/home/**` 매핑이 정확한지
2. 신규 PR 템플릿 구조가 팀 리뷰 흐름과 맞는지
3. Swagger 그룹 추가가 기존 그룹 노출이나 제목과 중복되지 않는지

## 3. 테스트 방법 (간단히)
- `./gradlew test`
- 수동 검증: Swagger UI에서 Home 그룹 노출 및 `/api/home/**` 응답 확인

## 4) 리스크/주의사항 (있으면)
- Swagger 그룹 스캔 경로 오타 시 Home API 미노출 가능
- 배포 환경에서 Swagger 문서 캐시/빌드가 갱신되었는지 확인 필요

## 🔗 Relation Issue
- close #91
