### PR TITLE
[REFACTOR] 가족 관계 미존재 시 404 대신 null 응답 처리

### DIFF
--- a/oneco/src/main/java/com/oneco/backend/family/application/port/in/GetFamilyMembersUseCase.java
+++ b/oneco/src/main/java/com/oneco/backend/family/application/port/in/GetFamilyMembersUseCase.java
@@ -1,9 +1,10 @@
 package com.oneco.backend.family.application.port.in;
 
+import java.util.Optional;
+
 import com.oneco.backend.family.application.dto.result.FamilyMembersResult;
 import com.oneco.backend.member.domain.MemberId;
 
 public interface GetFamilyMembersUseCase {
-	FamilyMembersResult getFamilyMembers(MemberId memberId);
+	Optional<FamilyMembersResult> getFamilyMembers(MemberId memberId);
 }
-

--- a/oneco/src/main/java/com/oneco/backend/family/application/service/FamilyMemberReadService.java
+++ b/oneco/src/main/java/com/oneco/backend/family/application/service/FamilyMemberReadService.java
@@ -1,6 +1,7 @@
 package com.oneco.backend.family.application.service;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,12 +28,12 @@ public class FamilyMemberReadService implements GetFamilyMembersUseCase {
 	private final MemberLookupPort memberLookupPort;
 
 	@Override
-	public FamilyMembersResult getFamilyMembers(MemberId memberId) {
+	public Optional<FamilyMembersResult> getFamilyMembers(MemberId memberId) {
 		List<FamilyRelation> relations = relationPort.findConnectedRelationsByMemberId(memberId);
 
-		// 가족 관계가 없는 경우 null 반환
+		// 가족 관계가 없는 경우 빈 Optional 반환
 		if (relations.isEmpty()) {
-			return null;
+			return Optional.empty();
 		}
 
 		// 상대방 멤버 정보 조회 및 결과 생성
@@ -40,7 +41,7 @@ public class FamilyMemberReadService implements GetFamilyMembersUseCase {
 			.map(relation -> resolveCounterpart(relation, memberId))
 			.toList();
 
-		return FamilyMembersResult.of(members);
+		return Optional.of(FamilyMembersResult.of(members));
 	}
 
 	// 요청자의 상대방 멤버 정보를 조회하는 메서드

--- a/oneco/src/main/java/com/oneco/backend/family/presentation/FamilyRelationController.java
+++ b/oneco/src/main/java/com/oneco/backend/family/presentation/FamilyRelationController.java
@@ -1,5 +1,7 @@
 package com.oneco.backend.family.presentation;
 
+import java.util.Optional;
+
 import org.springframework.http.CacheControl;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
@@ -161,8 +163,8 @@ public class FamilyRelationController {
 		@Parameter(hidden = true)
 		@AuthenticationPrincipal JwtPrincipal principal
 	) {
-		FamilyMembersResult result = getFamilyMembersUseCase.getFamilyMembers(MemberId.of(principal.memberId()));
-		FamilyMembersResponse response = result == null ? null : FamilyMembersResponse.from(result);
+		Optional<FamilyMembersResult> result = getFamilyMembersUseCase.getFamilyMembers(MemberId.of(principal.memberId()));
+		FamilyMembersResponse response = result.map(FamilyMembersResponse::from).orElse(null);
 
 		return ResponseEntity.ok(DataResponse.from(response));
 	}


### PR DESCRIPTION
## 1. 한줄 요약 (What / Why)
- What: 가족 구성원 조회 시 가족 관계가 없으면 예외 대신 `data=null`로 응답하도록 서비스/컨트롤러를 조정했습니다.
- Why: 가족이 없는 사용자의 정상 플로우에서 404가 아닌 200 응답으로 비어 있음을 전달해 클라이언트 처리 흐름을 단순화하려고 합니다.

## 2. 리뷰 포인트 (최대 3개)
1. 가족 관계 미존재 시 null 반환이 클라이언트/기존 소비자와의 호환성에 문제 없는지 확인해주세요.
2. `FamilyMembersResponse.from` 호출 전 null 체크 흐름이 NPE 없이 안정적으로 동작하는지 검토 바랍니다.
3. API 스펙 변경(200 + null 응답)으로 Swagger 설명이 충분한지, 추가 상태 코드가 필요한지 확인 요청드립니다.

## 3. 테스트 방법 (간단히)
- `./gradlew test`
- `GET /api/family/members` (가족 관계가 없으면 data=null, 있으면 가족 목록 반환)

## 4) 리스크/주의사항 (있으면)
- 이전에 404를 기대하던 클라이언트가 있다면 응답 계약 변경으로 처리 로직을 조정해야 합니다.

## 🔗 Relation Issue
- close #109
