### PR TITLE
[REFACTOR] 미션 생성 시 familyRelationId 제거

### DIFF
--- a/oneco/src/main/java/com/oneco/backend/mission/application/dto/CreateMissionCommand.java
+++ b/oneco/src/main/java/com/oneco/backend/mission/application/dto/CreateMissionCommand.java
@@ -6,7 +6,6 @@ import java.time.LocalDate;
 public record CreateMissionCommand(
 	Long requesterId,
 	Long recipientId,
-	Long familyRelationId,
 	Long categoryId,
 	LocalDate startDate,
 	LocalDate endDate,

--- a/oneco/src/main/java/com/oneco/backend/mission/application/port/out/FamilyRelationLookupPort.java
+++ b/oneco/src/main/java/com/oneco/backend/mission/application/port/out/FamilyRelationLookupPort.java
@@ -1,5 +1,7 @@
 package com.oneco.backend.mission.application.port.out;
 
+import java.util.Optional;
+
 import com.oneco.backend.family.domain.relation.FamilyRelationId;
 import com.oneco.backend.member.domain.MemberId;
 
@@ -10,4 +12,7 @@ public interface FamilyRelationLookupPort {
 
 	// memberId로 FamilyRelationId 조회
 	FamilyRelationId findRelationIdByMemberId(MemberId memberId);
+
+	// 요청자와 수신자의 연결된 가족 관계 ID 조회
+	Optional<FamilyRelationId> findConnectedRelationIdBetween(MemberId requesterId, MemberId recipientId);
 }

--- a/oneco/src/main/java/com/oneco/backend/mission/application/service/CreateMissionService.java
+++ b/oneco/src/main/java/com/oneco/backend/mission/application/service/CreateMissionService.java
@@ -45,13 +45,9 @@ public class CreateMissionService implements CreateMissionUseCase {
 		// recipientId 받아오기
 		MemberId recipientId = MemberId.of(requireNonNull(command.recipientId(), "recipient_id null 입니다."));
 
-		// FamilyRelation 받아오기
-		FamilyRelationId relationId = FamilyRelationId.of(requireNonNull(command.familyRelationId(), "FamilyRelationId가 null 입니다."));
-
-		// requesterId와 recipientId가 서로 FamilyRelation에 속하는지 검증한다.
-		if (!familyRelationLookupPort.isMembersOfRelation(relationId, requesterId, recipientId)) {
-			throw BaseException.from(MissionErrorCode.INVALID_FAMILY_RELATION_MEMBERS);
-		}
+		// FamilyRelation 받아오기 (요청자와 수신자가 연결된 관계인지 확인)
+		FamilyRelationId relationId = familyRelationLookupPort.findConnectedRelationIdBetween(requesterId, recipientId)
+			.orElseThrow(() -> BaseException.from(MissionErrorCode.INVALID_FAMILY_RELATION_MEMBERS));
 
 		// CategoryId 받아오기
 		CategoryId categoryId = CategoryId.of(requireNonNull(command.categoryId(), "CategoryId가 null 입니다."));

--- a/oneco/src/main/java/com/oneco/backend/mission/infrastructure/FamilyRelationLookupAdapter.java
+++ b/oneco/src/main/java/com/oneco/backend/mission/infrastructure/FamilyRelationLookupAdapter.java
@@ -1,5 +1,7 @@
 package com.oneco.backend.mission.infrastructure;
 
+import java.util.Optional;
+
 import org.springframework.stereotype.Component;
 
 import com.oneco.backend.family.domain.relation.FamilyRelation;
@@ -41,5 +43,14 @@ public class FamilyRelationLookupAdapter implements FamilyRelationLookupPort {
 			.findFirst()
 			.map(relation -> FamilyRelationId.of(relation.getId()))
 			.orElseThrow(() -> BaseException.from(FamilyErrorCode.FAMILY_RELATION_NOT_FOUND));
+	}
+
+	@Override
+	public Optional<FamilyRelationId> findConnectedRelationIdBetween(MemberId requesterId, MemberId recipientId) {
+		return repository.findConnectedRelationByMemberId(requesterId)
+			.stream()
+			.filter(relation -> isMembersMatched(relation, requesterId, recipientId))
+			.findFirst()
+			.map(relation -> FamilyRelationId.of(relation.getId()));
 	}
 }

--- a/oneco/src/main/java/com/oneco/backend/mission/presentation/request/CreateMissionRequest.java
+++ b/oneco/src/main/java/com/oneco/backend/mission/presentation/request/CreateMissionRequest.java
@@ -11,7 +11,6 @@ import com.oneco.backend.mission.application.dto.CreateMissionCommand;
 
 public record CreateMissionRequest(
 	@NotNull @Positive Long recipientId,
-	@NotNull @Positive Long familyRelationId,
 	@NotNull @Positive Long categoryId,
 
 	// Mission Period
@@ -27,7 +26,6 @@ public record CreateMissionRequest(
 		return new CreateMissionCommand(
 			requesterId,
 			recipientId,
-			familyRelationId,
 			categoryId,
 			startDate,
 			endDate,


### PR DESCRIPTION
## 1. 한줄 요약 (What / Why)
- What: 미션 생성 시 familyRelationId 입력을 없애고 요청자-수신자 연결 관계를 백엔드에서 조회해 사용하도록 변경했습니다.
- Why: API 스키마를 단순화하고 실제 연결된 가족 관계만으로 미션을 생성하도록 검증을 강화하기 위해서입니다.

## 2. 리뷰 포인트 (최대 3개)
1. requester/recipient 기반 `findConnectedRelationIdBetween`가 여러 관계가 있을 때 원하는 관계를 선택하는지 확인 필요
2. CreateMissionRequest에서 familyRelationId 제거에 따른 클라이언트/문서 호환성 영향 검토
3. 관계 조회 실패 시 INVALID_FAMILY_RELATION_MEMBERS 예외 처리/메시지가 적절한지 확인

## 3. 테스트 방법 (간단히)
- `./gradlew test`
- `POST /api/missions` (familyRelationId 없이 미션 생성 요청)

## 4) 리스크/주의사항 (있으면)
- 클라이언트가 여전히 familyRelationId를 전송하면 요청 바인딩/검증 오류가 발생할 수 있음
- 요청자 기준 첫 번째 연결 관계를 선택하므로 복수 관계가 있는 경우 의도한 관계인지 확인 필요

## 🔗 Relation Issue
- close #113
