### PR TITLE
[FEAT] 단건 미션 상세 조회 API

### DIFF
--- a/oneco/src/main/java/com/oneco/backend/mission/application/port/out/CategoryLookupPort.java
+++ b/oneco/src/main/java/com/oneco/backend/mission/application/port/out/CategoryLookupPort.java
@@ -2,11 +2,14 @@ package com.oneco.backend.mission.application.port.out;
 
 import com.oneco.backend.category.domain.category.CategoryId;
 import com.oneco.backend.category.domain.category.MissionDays;
+import com.oneco.backend.category.domain.category.CategoryTitle;
 
 
 // 카테고리 도메인 조회 포트
 public interface CategoryLookupPort {
 
 	MissionDays getDefaultMissionDays(CategoryId categoryId);
+
+	CategoryTitle getCategoryTitle(CategoryId categoryId);
 
 }

--- a/oneco/src/main/java/com/oneco/backend/mission/infrastructure/CategoryLookupJpaAdapter.java
+++ b/oneco/src/main/java/com/oneco/backend/mission/infrastructure/CategoryLookupJpaAdapter.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Component;
 import com.oneco.backend.category.domain.category.Category;
 import com.oneco.backend.category.domain.category.CategoryId;
 import com.oneco.backend.category.domain.category.MissionDays;
+import com.oneco.backend.category.domain.category.CategoryTitle;
 import com.oneco.backend.category.domain.exception.constant.CategoryErrorCode;
 import com.oneco.backend.category.infrastructure.CategoryJpaRepository;
 import com.oneco.backend.global.exception.BaseException;
@@ -22,6 +23,16 @@ public class CategoryLookupJpaAdapter implements CategoryLookupPort {
 	public MissionDays getDefaultMissionDays(CategoryId categoryId) {
 		return categoryJpaRepository.findById(categoryId.getValue())
 			.map(Category::getDefaultMissionDays)
+			.orElseThrow(() -> BaseException.from(
+				CategoryErrorCode.INVALID_CATEGORY_ID,
+				"Invalid categoryId: " + categoryId.getValue()
+			));
+	}
+
+	@Override
+	public CategoryTitle getCategoryTitle(CategoryId categoryId) {
+		return categoryJpaRepository.findById(categoryId.getValue())
+			.map(Category::getTitle)
 			.orElseThrow(() -> BaseException.from(
 				CategoryErrorCode.INVALID_CATEGORY_ID,
 				"Invalid categoryId: " + categoryId.getValue()

--- a/oneco/src/main/java/com/oneco/backend/mission/presentation/MissionController.java
+++ b/oneco/src/main/java/com/oneco/backend/mission/presentation/MissionController.java
@@ -23,6 +23,7 @@ import com.oneco.backend.mission.presentation.request.ApproveMissionRequest;
 import com.oneco.backend.mission.presentation.request.CreateMissionRequest;
 import com.oneco.backend.mission.presentation.request.MissionCursorRequest;
 import com.oneco.backend.mission.presentation.response.MissionCountResponse;
+import com.oneco.backend.mission.presentation.response.MissionDetailResponse;
 import com.oneco.backend.mission.presentation.response.MissionExistsResponse;
 import com.oneco.backend.mission.presentation.response.MissionResponse;
 
@@ -172,6 +173,27 @@ public class MissionController {
 	) {
 		MemberId memberId = MemberId.of(principal.memberId());
 		MissionExistsResponse response = missionReadService.existsInProgressMission(memberId);
+		return ResponseEntity.ok(DataResponse.from(response));
+	}
+
+	// missionId로 미션 단건 조회(미션 상세 조회용)
+	// 미션의 categoryTitle, rewardTitle, startDate, endDate를 포함한다.
+	@GetMapping("/{missionId}")
+	@Operation(
+		summary = "미션 단건 조회",
+		description = "미션 ID로 미션의 세부 정보를 조회한다."
+	)
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "미션 단건 조회 성공")
+	})
+	public ResponseEntity<DataResponse<MissionDetailResponse>> getMissionById(
+		@Parameter(description = "미션 ID", required = true)
+		@PathVariable Long missionId,
+		@Parameter(hidden = true)
+		@AuthenticationPrincipal JwtPrincipal principal
+	) {
+		MemberId memberId = MemberId.of(principal.memberId());
+		MissionDetailResponse response = missionReadService.getMissionDetailById(memberId, missionId);
 		return ResponseEntity.ok(DataResponse.from(response));
 	}
 }

--- a/oneco/src/main/java/com/oneco/backend/mission/presentation/response/MissionResponse.java
+++ b/oneco/src/main/java/com/oneco/backend/mission/presentation/response/MissionResponse.java
@@ -2,7 +2,7 @@ package com.oneco.backend.mission.presentation.response;
 
 public record MissionResponse(
 	Long missionId,
-	String missionTitle,
+	String categoryTitle,
 	String rewardTitle,
 	String missionStatus
 ) {


### PR DESCRIPTION
## 1. 한줄 요약 (What / Why)
- What: 미션 목록 응답에 카테고리 제목을 조회해 노출하고, 미션 단건 상세 조회 API를 추가했습니다.
- Why: 식별자 대신 사용자가 이해하기 쉬운 제목을 제공하고, 가족 관계를 검증한 뒤 세부 정보를 확인할 수 있도록 하기 위해서입니다.

## 2. 리뷰 포인트 (최대 3개)
1. CategoryLookupPort에 추가된 제목 조회가 JPA 어댑터 예외 처리/성능에 적합한지
2. getMissionDetailById에서 가족 관계 검증과 에러 코드(MissionErrorCode.INVALID_FAMILY_RELATION_MEMBERS) 사용이 적절한지
3. MissionResponse의 필드명이 categoryTitle로 변경됨에 따라 클라이언트 호환성 영향 여부

## 3. 테스트 방법 (간단히)
- `./gradlew test`
- `GET /api/missions/{missionId}` (인가된 회원으로 상세 조회)

## 4) 리스크/주의사항 (있으면)
- 목록 응답 필드명이 missionTitle → categoryTitle로 바뀌어 기존 소비자가 있다면 대응 필요
- 미션 상세 조회 시 카테고리 타이틀 조회로 인한 추가 DB 접근이 허용 가능한지 확인 필요

## 🔗 Relation Issue
- close #117
