### PR TITLE
[BUGFIX] 부모가 홈화면 조회시 자녀의 학습기록이 아닌 본인의 학습기록을 조회하는 버그 수정

### DIFF
--- a/oneco/src/main/java/com/oneco/backend/StudyRecord/application/port/dto/result/HomeDashboardResult.java
+++ b/oneco/src/main/java/com/oneco/backend/StudyRecord/application/port/dto/result/HomeDashboardResult.java
@@ -29,6 +29,7 @@ public record HomeDashboardResult(
 
 	public record MissionResult(
 		Long missionId,
+		Long childId,
 		Long categoryId,
 		String rewardTitle,
 		LocalDate startDate,
@@ -36,12 +37,13 @@ public record HomeDashboardResult(
 	) {
 		public static MissionResult of(
 			Long missionId,
+			Long childId,
 			Long categoryId,
 			String rewardTitle,
 			LocalDate startDate,
 			LocalDate endDate
 		) {
-			return new MissionResult(missionId, categoryId, rewardTitle, startDate, endDate);
+			return new MissionResult(missionId, childId, categoryId, rewardTitle, startDate, endDate);
 		}
 	}
 

--- a/oneco/src/main/java/com/oneco/backend/StudyRecord/application/service/GetHomeDashboardService.java
+++ b/oneco/src/main/java/com/oneco/backend/StudyRecord/application/service/GetHomeDashboardService.java
@@ -158,11 +158,9 @@ public class GetHomeDashboardService implements GetHomeDashboardUseCase {
 			dailyContent.contentKeyword()
 		);
 
-		Long studyMemberId = mission.childId();
-
 		// 5. 캘린더 상태 계산을 위해 StudyRecord 목록 조회
 		List<StudyRecord> records = repository.findByMemberIdAndMissionIdAndCategoryId(
-			studyMemberId,
+			mission.childId(),
 			mission.missionId(),
 			mission.categoryId()
 		);

--- a/oneco/src/main/java/com/oneco/backend/StudyRecord/infrastructure/persistence/HomeDashboardMissionReadAdapter.java
+++ b/oneco/src/main/java/com/oneco/backend/StudyRecord/infrastructure/persistence/HomeDashboardMissionReadAdapter.java
@@ -61,7 +61,7 @@ public class HomeDashboardMissionReadAdapter implements HomeDashboardMissionRead
 
 	// FamilyRelation -> ChildId 추출한다.
 	private Long extractChildId(Long familyRelationId) {
-		return familyRelationJpaRepository.findById(familyRelationId)
+		return familyRelationJpaRepository.findById(familyRelationId) // DB 조회 1번
 			.map(relation -> relation.getChildId().getValue())
 			.orElseThrow(() -> BaseException.from(FamilyErrorCode.FAMILY_RELATION_NOT_FOUND));
 	}

--- a/oneco/src/main/java/com/oneco/backend/category/domain/exception/constant/CategoryErrorCode.java
+++ b/oneco/src/main/java/com/oneco/backend/category/domain/exception/constant/CategoryErrorCode.java
@@ -33,7 +33,8 @@ public enum CategoryErrorCode implements ErrorCode {
 		"CATEGORY_400_007"),
 	CATEGORY_MISSION_DAYS_OUT_OF_RANGE(HttpStatus.BAD_REQUEST, "정해진 일자에서 벗어났습니다.",
 		"CATEGORY_400_008"),
-	INVALID_CATEGORY_ID(HttpStatus.BAD_REQUEST, "카테고리 ID가 유효하지 않습니다.","CATEGORY_ERROR_401_INVALID_CATEGORY_ID");
+	INVALID_CATEGORY_ID(HttpStatus.BAD_REQUEST, "카테고리 ID가 유효하지 않습니다.",
+		"CATEGORY_ERROR_401_INVALID_CATEGORY_ID");
 
 	private final HttpStatus httpStatus;
 	private final String message;

--- a/oneco/src/main/java/com/oneco/backend/mission/domain/mission/MissionDateCalculator.java
+++ b/oneco/src/main/java/com/oneco/backend/mission/domain/mission/MissionDateCalculator.java
@@ -24,7 +24,7 @@ public final class MissionDateCalculator {
 		LocalDate today
 	) {
 
-		log.info("openedDaySequenceExcludeWeekend 호출 startDate={}, endDate={}, today={}",
+		log.info("[openedDaySequenceExcludeWeekend 시작] - startDate={}, endDate={}, today={}",
 			startDate, endDate, today);
 
 		if (today == null) {
@@ -37,7 +37,7 @@ public final class MissionDateCalculator {
 
 		// 2) 미션 시작 전이면 진행 일수는 0이다.
 		if (effectiveEnd.isBefore(startDate)) {
-			log.info("오늘 날짜가 미션 시작일 이전이므로 진행 일수는 0으로 처리합니다. startDate={}, effectiveEnd={}",
+			log.info("today가 startDate 과거이므로 진행 일수는 0으로 처리 startDate={}, effectiveEnd={}",
 				startDate, effectiveEnd);
 			return 0;
 		}
@@ -65,8 +65,8 @@ public final class MissionDateCalculator {
 			cursor = cursor.plusDays(1);
 		}
 
-		log.info("평일 일수 weekdays={}", weekdays);
-		log.info("openedDaySequenceExcludeWeekend 호출 끝");
+		log.info("평일 일수 weekdays: {}", weekdays);
+		log.info("[openedDaySequenceExcludeWeekend 종료]");
 		return (int)weekdays;
 
 	}


### PR DESCRIPTION
## 1. 한줄 요약 (What / Why)
- What: 홈 대시보드 미션 결과에 childId를 포함하고 StudyRecord 조회 키를 memberId에서 childId로 교체하며 로깅/주석을 정비했습니다.
- Why: 부모 계정으로 홈 대시보드를 조회할 때 자녀 학습 기록이 누락되지 않도록 식별자를 통일하고, 조회·일자 계산 흐름을 추적하기 위함입니다.

## 2. 리뷰 포인트 (최대 3개)
1. FamilyRelation 기반 childId 추출 로직과 예외 처리(미존재 시 전체 실패)가 적절한지
2. StudyRecord 조회 조건을 childId로 변경한 것이 다른 호출부/권한 모델과 충돌하지 않는지
3. 추가된 상세 로그의 노출 수준과 성능 영향이 허용 가능한지

## 3. 테스트 방법 (간단히)
- `./gradlew test`
- `GET /api/home/dashboard` (parent/child 토큰, missionId 미지정 시 최신 미션 기준)으로 진행률·캘린더가 자녀 기록 기준으로 계산되는지 확인

## 4) 리스크/주의사항 (있으면)
- FamilyRelation 조회 실패 시 홈 대시보드가 BaseException으로 즉시 실패
- 추가 발견된 리스크 없음

## 🔗 Relation Issue
- close #140
